### PR TITLE
Refactor DeckEndpoint Routes to Use Route Parameters

### DIFF
--- a/Croupier.App/Endpoints/DeckEndpoint.cs
+++ b/Croupier.App/Endpoints/DeckEndpoint.cs
@@ -12,10 +12,10 @@ public class DeckEndpoint : IEndpoint
     }
     public void RegisterRoutes(IEndpointRouteBuilder app)
     {
-        app.MapGet("/new-game", NewSession);
-        app.MapGet("/draw-card", DrawCard);
-        app.MapGet("/see-deck", SeeDeck);
-        app.MapGet("/shuffle-deck", ShuffleDeck);
+        app.MapGet("/new-game/{numberOfDecks?}", NewSession);
+        app.MapGet("/draw-card/{sessionId}", DrawCard);
+        app.MapGet("/see-deck/{sessionId}", SeeDeck);
+        app.MapGet("/shuffle-deck/{sessionId}", ShuffleDeck);
     }
 
     //TODO: add some asynchronicity to the application

--- a/Croupier.App/Workers/SessionManager.cs
+++ b/Croupier.App/Workers/SessionManager.cs
@@ -9,29 +9,33 @@ public class SessionManager : ISessionManager
     {
         _sessions = new();
     }
+    // Extracted helper to find a session by ID
+    private Session? FindSession(string sessionId) => _sessions.FirstOrDefault(s => s.SessionId == sessionId);
+
     public string NewSession(int? numberOfDecks)
     {
         _sessions.Add(new Session(numberOfDecks ?? 1));
         return _sessions.Last().SessionId;
     }
+
     public Session? GetSession(string sessionId)
     {
-        return _sessions.FirstOrDefault(s => s.SessionId == sessionId);
+        return FindSession(sessionId);
     }
+
     public Card? DrawCard(string sessionId)
     {
-        return _sessions.FirstOrDefault(s => s.SessionId == sessionId)?
-                .Cards.Cards.Pop();
+        return FindSession(sessionId)?.Cards.Cards.Pop();
     }
+
     public Stack<Card>? SeeDeck(string sessionId)
     {
-        return _sessions.FirstOrDefault(s => s.SessionId == sessionId)?
-                .Cards.Cards;
+        return FindSession(sessionId)?.Cards.Cards;
     }
+
     public Stack<Card>? ShuffleDeck(string sessionId)
     {
-        var deck = _sessions.FirstOrDefault(s => s.SessionId == sessionId)?
-                    .Cards;
+        var deck = FindSession(sessionId)?.Cards;
 
         if (deck != null)
         {

--- a/Croupier.App/Workers/SessionManager.cs
+++ b/Croupier.App/Workers/SessionManager.cs
@@ -25,7 +25,17 @@ public class SessionManager : ISessionManager
 
     public Card? DrawCard(string sessionId)
     {
-        return FindSession(sessionId)?.Cards.Cards.Pop();
+        var session = FindSession(sessionId);
+        if (session == null)
+        {
+            return null;
+        }
+        var cards = session.Cards.Cards;
+        if (cards.Count == 0)
+        {
+            return null;
+        }
+        return cards.Pop();
     }
 
     public Stack<Card>? SeeDeck(string sessionId)

--- a/Croupier.Tests/CroupierTests.cs
+++ b/Croupier.Tests/CroupierTests.cs
@@ -29,7 +29,7 @@ public class CroupierTests
     public async Task NormalDeckContains52Cards()
     {
         var id = await _client.GetStringAsync("/new-game");
-        var result = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var result = await _client.GetAsync($"/see-deck/{id}");
 
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         var deck = await result.Content.ReadAsStringAsync();
@@ -38,8 +38,8 @@ public class CroupierTests
     [Fact]
     public async Task MultipleDeckContainsCorrectNumberOfCards()
     {
-        var id = await _client.GetStringAsync("/new-game?numberOfDecks=3");
-        var result = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var id = await _client.GetStringAsync("/new-game/3");
+        var result = await _client.GetAsync($"/see-deck/{id}");
 
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         var deck = await result.Content.ReadAsStringAsync();
@@ -49,15 +49,15 @@ public class CroupierTests
     [Fact]
     public async Task ShufflerReallyShuffles()
     {
-        var id = await _client.GetStringAsync("/new-game?numberOfDecks=3");
-        var result = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var id = await _client.GetStringAsync("/new-game/3");
+        var result = await _client.GetAsync($"/see-deck/{id}");
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
         var deck = JsonSerializer.Deserialize<List<Card>>(
             await result.Content.ReadAsStringAsync()
         );
 
-        var shuffledResponse = await _client.GetAsync("/shuffle-deck?sessionId=" + id);
+        var shuffledResponse = await _client.GetAsync($"/shuffle-deck/{id}");
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
         var shuffledDeck = JsonSerializer.Deserialize<List<Card>>(
@@ -74,7 +74,7 @@ public class CroupierTests
     public async Task DrawCardDrawsOnlyOneCard()
     {
         var id = await _client.GetStringAsync("/new-game");
-        var result = await _client.GetAsync("/draw-card?sessionId=" + id);
+        var result = await _client.GetAsync($"/draw-card/{id}");
 
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         
@@ -85,37 +85,37 @@ public class CroupierTests
     [Fact]
     public async Task DrawCardDrawsCardOnTopOfDeck()
     {
-        var id = await _client.GetStringAsync("/new-game?numberOfDecks=1");
+        var id = await _client.GetStringAsync("/new-game/1");
 
-        var result = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var result = await _client.GetAsync($"/see-deck/{id}");
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
         var deck = JsonSerializer.Deserialize<List<Card>>(
             await result.Content.ReadAsStringAsync()
         );
 
-        var cardResult = await _client.GetAsync("/draw-card?sessionId=" + id);
+        var cardResult = await _client.GetAsync($"/draw-card/{id}");
         var card = JsonSerializer.Deserialize<Card>(
             await cardResult.Content.ReadAsStringAsync()
         );
         
-        Assert.Equal(deck[0],card);
+        Assert.Equal(deck[0], card!);
     }
     [Fact]
     public async Task DrawCardRemovesCardFromDeck()
     {
-        var id = await _client.GetStringAsync("/new-game?numberOfDecks=1");
+        var id = await _client.GetStringAsync("/new-game/1");
 
-        var result = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var result = await _client.GetAsync($"/see-deck/{id}");
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
-        var deck = JsonSerializer.Deserialize<List<Card>>(
+        var deck = JsonSerializer.Deserialize<List<Card>>(    
             await result.Content.ReadAsStringAsync()
         );
 
-        await _client.GetAsync("/draw-card?sessionId=" + id);
+        await _client.GetAsync($"/draw-card/{id}");
         
-        var resultAfterDraw = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var resultAfterDraw = await _client.GetAsync($"/see-deck/{id}");
         Assert.Equal(HttpStatusCode.OK, resultAfterDraw.StatusCode);
 
         var deckAfterDraw = JsonSerializer.Deserialize<List<Card>>(
@@ -129,23 +129,24 @@ public class CroupierTests
     [Fact]
     public async Task DrawingAllCardsEmptiesDeck()
     {
-        var id = await _client.GetStringAsync("/new-game?numberOfDecks=1");
+        var id = await _client.GetStringAsync("/new-game/1");
 
-        Enumerable.Range(1,52).ToList().ForEach(e => {
-            _client.GetAsync("/draw-card?sessionId=" + id);
-        });
+        // Draw all 52 cards by awaiting each request
+        for (int i = 0; i < 52; i++)
+        {
+            await _client.GetAsync($"/draw-card/{id}");
+        }
         
-        var voidDraw = await _client.GetAsync("/draw-card?sessionId=" + id);
+        var voidDraw = await _client.GetAsync($"/draw-card/{id}");
         var card = JsonSerializer.Deserialize<Card>(
             await voidDraw.Content.ReadAsStringAsync()
         );
         
-        var result = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var result = await _client.GetAsync($"/see-deck/{id}");
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
         var deck = await result.Content.ReadAsStringAsync();
         Console.WriteLine(deck);
         Assert.Null(card?.code);
     }
-    //TODO: refactor querystring to become a route param
 }


### PR DESCRIPTION
This PR refactors the DeckEndpoint routes to use route parameters instead of query strings for improved REST semantics and convenience.

- Updated /new-game, /draw-card, /see-deck, and /shuffle-deck endpoints to accept parameters in the route path.
- Refactored unit tests to use the new route formats.
- Enhanced SessionManager.DrawCard to gracefully return null when the deck is empty.

All existing tests have been updated accordingly and now pass successfully.

Closes issue #8.