### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/Croupier.App/Croupier.csproj
+++ b/Croupier.App/Croupier.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>7fe74da6-b780-48a1-a21a-53f0e57cb045</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" Version="1.3.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.6.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
   </ItemGroup>
 
 </Project>

--- a/Croupier.Tests/Croupier.Tests.csproj
+++ b/Croupier.Tests/Croupier.Tests.csproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.OpenApi" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates the target framework and package dependencies for both the main application and its test project to align with the latest versions and improve compatibility and functionality.

Framework updates:

* [`Croupier.App/Croupier.csproj`](diffhunk://#diff-862e43aefd4d75028bf4860ec879ce4cc73758b740c7d472878fd1b3a4ee09e4L4-R13): Updated the target framework from `net6.0` to `net8.0` to leverage the latest features and improvements in .NET 8.
* [`Croupier.Tests/Croupier.Tests.csproj`](diffhunk://#diff-f88d48d3e9e2067a54af699ff2490f6ed68b556e44bcc1ac535acf141bb84e31L4-R18): Updated the target framework from `net6.0` to `net8.0` for consistency with the main application and to use .NET 8 features.

Package dependency updates:

* [`Croupier.App/Croupier.csproj`](diffhunk://#diff-862e43aefd4d75028bf4860ec879ce4cc73758b740c7d472878fd1b3a4ee09e4L4-R13): Upgraded `Microsoft.OpenApi` to version `1.6.0`, `Swashbuckle.AspNetCore.SwaggerGen` to version `6.5.0`, and `Swashbuckle.AspNetCore.SwaggerUI` to version `6.5.0` for improved API documentation capabilities.
* [`Croupier.Tests/Croupier.Tests.csproj`](diffhunk://#diff-f88d48d3e9e2067a54af699ff2490f6ed68b556e44bcc1ac535acf141bb84e31L4-R18): Updated `Microsoft.AspNetCore.Mvc.Testing` and `Microsoft.AspNetCore.TestHost` to version `8.0.0`, and `Microsoft.NET.Test.Sdk` to version `17.8.0` to ensure compatibility with .NET 8. Also added `Microsoft.OpenApi` version `1.6.0` to the test project dependencies..