### PR TITLE
chore: update solution to .NET 8

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,9 @@
+* never ever let a method have more than 5 parameters
+* always use descriptive names for variables, methods, and classes
+* always use single quotes for strings
+
+* always validate input data before processing requests
+* use dependency injection for services and data access
+* prefer async methods for I/O-bound operations
+* organize endpoints logically using route groups or controllers
+* return appropriate HTTP status codes for all responses

--- a/Croupier.App/Croupier.csproj
+++ b/Croupier.App/Croupier.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>7fe74da6-b780-48a1-a21a-53f0e57cb045</UserSecretsId>

--- a/Croupier.App/Endpoints/DeckEndpoint.cs
+++ b/Croupier.App/Endpoints/DeckEndpoint.cs
@@ -4,18 +4,16 @@ using Croupier.Workers;
 namespace Croupier.Endpoints;
 
 public class DeckEndpoint : IEndpoint    
-{
-    private ISessionManager _manager;
+{    private readonly ISessionManager _manager;
     public DeckEndpoint(IServiceProvider serviceProvider)
     {
-        _manager = serviceProvider.GetService<ISessionManager>() ?? throw new ArgumentNullException(nameof(ISessionManager));
-    }
-    public void RegisterRoutes(IEndpointRouteBuilder app)
+        _manager = serviceProvider.GetService<ISessionManager>() ?? throw new ArgumentNullException(nameof(serviceProvider), "ISessionManager not registered");
+    }public void RegisterRoutes(IEndpointRouteBuilder app)
     {
-        app.MapGet("/new-game", NewSession);
-        app.MapGet("/draw-card", DrawCard);
-        app.MapGet("/see-deck", SeeDeck);
-        app.MapGet("/shuffle-deck", ShuffleDeck);
+        app.MapGet("/new-game/{numberOfDecks:int?}", NewSession);
+        app.MapGet("/sessions/{sessionId}/draw-card", DrawCard);
+        app.MapGet("/sessions/{sessionId}/see-deck", SeeDeck);
+        app.MapPost("/sessions/{sessionId}/shuffle-deck", ShuffleDeck);
     }
 
     //TODO: add some asynchronicity to the application
@@ -26,9 +24,7 @@ public class DeckEndpoint : IEndpoint
     public Card? DrawCard(string sessionId)
     {
         return _manager.DrawCard(sessionId);
-    }
-    //TODO: make it route param and not querystring
-    public Stack<Card>? SeeDeck(string sessionId)
+    }    public Stack<Card>? SeeDeck(string sessionId)
     {
         return _manager.SeeDeck(sessionId);
     }

--- a/Croupier.App/Workers/SessionManager.cs
+++ b/Croupier.App/Workers/SessionManager.cs
@@ -8,20 +8,22 @@ public class SessionManager : ISessionManager
     public SessionManager()
     {
         _sessions = new();
-    }
-    public string NewSession(int? numberOfDecks)
+    }    public string NewSession(int? numberOfDecks)
     {
         _sessions.Add(new Session(numberOfDecks ?? 1));
-        return _sessions.Last().SessionId;
+        return _sessions[_sessions.Count - 1].SessionId;
     }
     public Session? GetSession(string sessionId)
     {
         return _sessions.FirstOrDefault(s => s.SessionId == sessionId);
-    }
-    public Card? DrawCard(string sessionId)
+    }    public Card? DrawCard(string sessionId)
     {
-        return _sessions.FirstOrDefault(s => s.SessionId == sessionId)?
-                .Cards.Cards.Pop();
+        var session = _sessions.FirstOrDefault(s => s.SessionId == sessionId);
+        if (session?.Cards.Cards.Count > 0)
+        {
+            return session.Cards.Cards.Pop();
+        }
+        return null;
     }
     public Stack<Card>? SeeDeck(string sessionId)
     {

--- a/Croupier.Tests/Croupier.Tests.csproj
+++ b/Croupier.Tests/Croupier.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Croupier.Tests/CroupierTests.cs
+++ b/Croupier.Tests/CroupierTests.cs
@@ -24,41 +24,37 @@ public class CroupierTests
     {
         var id = await _client.GetStringAsync("/new-game");
         Assert.True(id.Length > 5 && id.Length < 10);
-    }
-    [Fact]
+    }    [Fact]
     public async Task NormalDeckContains52Cards()
     {
         var id = await _client.GetStringAsync("/new-game");
-        var result = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var result = await _client.GetAsync($"/sessions/{id}/see-deck");
 
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         var deck = await result.Content.ReadAsStringAsync();
         Assert.Equal(52, JsonSerializer.Deserialize<List<Card>>(deck)?.Count);
-    }
-    [Fact]
+    }    [Fact]
     public async Task MultipleDeckContainsCorrectNumberOfCards()
     {
-        var id = await _client.GetStringAsync("/new-game?numberOfDecks=3");
-        var result = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var id = await _client.GetStringAsync("/new-game/3");
+        var result = await _client.GetAsync($"/sessions/{id}/see-deck");
 
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         var deck = await result.Content.ReadAsStringAsync();
         Assert.Equal(3 * 52, JsonSerializer.Deserialize<List<Card>>(deck)?.Count);
-    }
-
-    [Fact]
+    }    [Fact]
     public async Task ShufflerReallyShuffles()
     {
-        var id = await _client.GetStringAsync("/new-game?numberOfDecks=3");
-        var result = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var id = await _client.GetStringAsync("/new-game/3");
+        var result = await _client.GetAsync($"/sessions/{id}/see-deck");
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
         var deck = JsonSerializer.Deserialize<List<Card>>(
             await result.Content.ReadAsStringAsync()
         );
 
-        var shuffledResponse = await _client.GetAsync("/shuffle-deck?sessionId=" + id);
-        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        var shuffledResponse = await _client.PostAsync($"/sessions/{id}/shuffle-deck", null);
+        Assert.Equal(HttpStatusCode.OK, shuffledResponse.StatusCode);
 
         var shuffledDeck = JsonSerializer.Deserialize<List<Card>>(
             await shuffledResponse.Content.ReadAsStringAsync()
@@ -69,53 +65,52 @@ public class CroupierTests
         Assert.Equal(deck.Count, shuffledDeck.Count);
 
         Assert.False(deck.SequenceEqual(shuffledDeck));
-    }
-    [Fact]
+    }    [Fact]
     public async Task DrawCardDrawsOnlyOneCard()
     {
         var id = await _client.GetStringAsync("/new-game");
-        var result = await _client.GetAsync("/draw-card?sessionId=" + id);
+        var result = await _client.GetAsync($"/sessions/{id}/draw-card");
 
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         
         Assert.IsType<Card>(JsonSerializer.Deserialize<Card>(
             await result.Content.ReadAsStringAsync()
         ));
-    }
-    [Fact]
+    }    [Fact]
     public async Task DrawCardDrawsCardOnTopOfDeck()
     {
-        var id = await _client.GetStringAsync("/new-game?numberOfDecks=1");
+        var id = await _client.GetStringAsync("/new-game/1");
 
-        var result = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var result = await _client.GetAsync($"/sessions/{id}/see-deck");
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
         var deck = JsonSerializer.Deserialize<List<Card>>(
             await result.Content.ReadAsStringAsync()
         );
 
-        var cardResult = await _client.GetAsync("/draw-card?sessionId=" + id);
+        var cardResult = await _client.GetAsync($"/sessions/{id}/draw-card");
         var card = JsonSerializer.Deserialize<Card>(
             await cardResult.Content.ReadAsStringAsync()
         );
         
-        Assert.Equal(deck[0],card);
-    }
-    [Fact]
+        Assert.NotNull(deck);
+        Assert.NotNull(card);
+        Assert.Equal(deck[0], card);
+    }    [Fact]
     public async Task DrawCardRemovesCardFromDeck()
     {
-        var id = await _client.GetStringAsync("/new-game?numberOfDecks=1");
+        var id = await _client.GetStringAsync("/new-game/1");
 
-        var result = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var result = await _client.GetAsync($"/sessions/{id}/see-deck");
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
         var deck = JsonSerializer.Deserialize<List<Card>>(
             await result.Content.ReadAsStringAsync()
         );
 
-        await _client.GetAsync("/draw-card?sessionId=" + id);
+        await _client.GetAsync($"/sessions/{id}/draw-card");
         
-        var resultAfterDraw = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var resultAfterDraw = await _client.GetAsync($"/sessions/{id}/see-deck");
         Assert.Equal(HttpStatusCode.OK, resultAfterDraw.StatusCode);
 
         var deckAfterDraw = JsonSerializer.Deserialize<List<Card>>(
@@ -124,28 +119,25 @@ public class CroupierTests
 
         Assert.NotNull(deck);
         Assert.NotNull(deckAfterDraw);
-        Assert.Equal(deck[1],deckAfterDraw[0]);
-    }
-    [Fact]
+        Assert.Equal(deck[1], deckAfterDraw[0]);
+    }    [Fact]
     public async Task DrawingAllCardsEmptiesDeck()
-    {
-        var id = await _client.GetStringAsync("/new-game?numberOfDecks=1");
+    {        var id = await _client.GetStringAsync("/new-game/1");
 
-        Enumerable.Range(1,52).ToList().ForEach(e => {
-            _client.GetAsync("/draw-card?sessionId=" + id);
-        });
+        for (int i = 0; i < 52; i++)
+        {
+            await _client.GetAsync($"/sessions/{id}/draw-card");
+        }
         
-        var voidDraw = await _client.GetAsync("/draw-card?sessionId=" + id);
+        var voidDraw = await _client.GetAsync($"/sessions/{id}/draw-card");
         var card = JsonSerializer.Deserialize<Card>(
             await voidDraw.Content.ReadAsStringAsync()
         );
         
-        var result = await _client.GetAsync("/see-deck?sessionId=" + id);
+        var result = await _client.GetAsync($"/sessions/{id}/see-deck");
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
-        var deck = await result.Content.ReadAsStringAsync();
-        Console.WriteLine(deck);
+        var deck = await result.Content.ReadAsStringAsync();        Console.WriteLine(deck);
         Assert.Null(card?.code);
     }
-    //TODO: refactor querystring to become a route param
 }

--- a/Croupier.Tests/TestResults/test_results.trx
+++ b/Croupier.Tests/TestResults/test_results.trx
@@ -1,0 +1,104 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TestRun id="ac6b7368-f088-4e38-9275-60c070d624a3" name="BrunoSilva@RM-8RM4BY3 2025-06-17 12:26:49" runUser="AzureAD\BrunoSilva" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <Times creation="2025-06-17T12:26:49.8755658-05:00" queuing="2025-06-17T12:26:49.8755661-05:00" start="2025-06-17T12:26:48.6581895-05:00" finish="2025-06-17T12:26:49.8905621-05:00" />
+  <TestSettings name="default" id="78c6b6fa-29a1-408e-a9c4-723d18532c65">
+    <Deployment runDeploymentRoot="BrunoSilva_RM-8RM4BY3_2025-06-17_12_26_49" />
+  </TestSettings>
+  <Results>
+    <UnitTestResult executionId="bfa4a2df-e404-47ce-8876-8e951f6f989b" testId="4f74a991-d890-bc0a-4793-026aa044837b" testName="Croupier.Tests.CroupierTests.DrawCardDrawsOnlyOneCard" computerName="RM-8RM4BY3" duration="00:00:00.0117080" startTime="2025-06-17T12:26:49.7475661-05:00" endTime="2025-06-17T12:26:49.7475662-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="bfa4a2df-e404-47ce-8876-8e951f6f989b" />
+    <UnitTestResult executionId="f97984f1-6399-4555-aeeb-7aa494315d19" testId="9d2ee00f-f190-32b7-5ef9-2c5503fb7f8f" testName="Croupier.Tests.CroupierTests.NormalDeckContains52Cards" computerName="RM-8RM4BY3" duration="00:00:00.0118471" startTime="2025-06-17T12:26:49.7244390-05:00" endTime="2025-06-17T12:26:49.7244392-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f97984f1-6399-4555-aeeb-7aa494315d19" />
+    <UnitTestResult executionId="07a786a0-ce17-49d5-bcb6-34ab04a0c64a" testId="936752f3-9fa4-e682-e9dd-c81b95bb96b6" testName="Croupier.Tests.CroupierTests.ShufflerReallyShuffles" computerName="RM-8RM4BY3" duration="00:00:00.1304044" startTime="2025-06-17T12:26:49.6529911-05:00" endTime="2025-06-17T12:26:49.6530033-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="07a786a0-ce17-49d5-bcb6-34ab04a0c64a" />
+    <UnitTestResult executionId="97bf5763-a489-4ef7-b5cc-3748936e25a8" testId="226d5946-baf1-6506-ddc7-4e01877606ea" testName="Croupier.Tests.CroupierTests.DrawingAllCardsEmptiesDeck" computerName="RM-8RM4BY3" duration="00:00:00.0241093" startTime="2025-06-17T12:26:49.6857988-05:00" endTime="2025-06-17T12:26:49.6857992-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="97bf5763-a489-4ef7-b5cc-3748936e25a8">
+      <Output>
+        <ErrorInfo>
+          <Message>Assert.Null() Failure&#xD;
+Expected: (null)&#xD;
+Actual:   2S</Message>
+          <StackTrace>   at Croupier.Tests.CroupierTests.DrawingAllCardsEmptiesDeck() in C:\git\Croupier\Croupier.Tests\CroupierTests.cs:line 148&#xD;
+--- End of stack trace from previous location ---</StackTrace>
+        </ErrorInfo>
+      </Output>
+    </UnitTestResult>
+    <UnitTestResult executionId="39cbebd2-e689-45a2-a5a6-f7e17fbcc20f" testId="bc389c86-95f2-56a2-8c3f-588e37d9d178" testName="Croupier.Tests.CroupierTests.DrawCardDrawsCardOnTopOfDeck" computerName="RM-8RM4BY3" duration="00:00:00.0116062" startTime="2025-06-17T12:26:49.7357424-05:00" endTime="2025-06-17T12:26:49.7357425-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="39cbebd2-e689-45a2-a5a6-f7e17fbcc20f" />
+    <UnitTestResult executionId="fc8a18af-b7da-459d-8dd3-85bbc6d2a51b" testId="28532d74-e399-4ef0-7be6-95e7edcbed42" testName="Croupier.Tests.CroupierTests.MultipleDeckContainsCorrectNumberOfCards" computerName="RM-8RM4BY3" duration="00:00:00.0123178" startTime="2025-06-17T12:26:49.7600053-05:00" endTime="2025-06-17T12:26:49.7600054-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fc8a18af-b7da-459d-8dd3-85bbc6d2a51b" />
+    <UnitTestResult executionId="016116e5-442c-409b-a99e-ec403f3a09b5" testId="3369af1c-e9ca-bebb-79c6-00bd1af362ef" testName="Croupier.Tests.CroupierTests.NewGameIdLengthEqualsEight" computerName="RM-8RM4BY3" duration="00:00:00.0127235" startTime="2025-06-17T12:26:49.7120753-05:00" endTime="2025-06-17T12:26:49.7120754-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="016116e5-442c-409b-a99e-ec403f3a09b5" />
+    <UnitTestResult executionId="4a6f3b2d-528a-4374-97fd-8e01ffaea53d" testId="55d9431b-d75a-b49a-a9ae-b74b239b906a" testName="Croupier.Tests.CroupierTests.DrawCardRemovesCardFromDeck" computerName="RM-8RM4BY3" duration="00:00:00.0163308" startTime="2025-06-17T12:26:49.6992510-05:00" endTime="2025-06-17T12:26:49.6992511-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4a6f3b2d-528a-4374-97fd-8e01ffaea53d" />
+    <UnitTestResult executionId="c5e03c5c-9bf4-4fd8-9c77-bb9d9a60a99d" testId="05c769be-168f-8b17-063c-1f1e2f514764" testName="Croupier.Tests.CroupierTests.NewGameReturnsId" computerName="RM-8RM4BY3" duration="00:00:00.0207256" startTime="2025-06-17T12:26:49.7808365-05:00" endTime="2025-06-17T12:26:49.7808367-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c5e03c5c-9bf4-4fd8-9c77-bb9d9a60a99d" />
+  </Results>
+  <TestDefinitions>
+    <UnitTest name="Croupier.Tests.CroupierTests.ShufflerReallyShuffles" storage="c:\git\croupier\croupier.tests\bin\debug\net8.0\croupier.tests.dll" id="936752f3-9fa4-e682-e9dd-c81b95bb96b6">
+      <Execution id="07a786a0-ce17-49d5-bcb6-34ab04a0c64a" />
+      <TestMethod codeBase="C:\git\Croupier\Croupier.Tests\bin\Debug\net8.0\Croupier.Tests.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="Croupier.Tests.CroupierTests" name="ShufflerReallyShuffles" />
+    </UnitTest>
+    <UnitTest name="Croupier.Tests.CroupierTests.NewGameReturnsId" storage="c:\git\croupier\croupier.tests\bin\debug\net8.0\croupier.tests.dll" id="05c769be-168f-8b17-063c-1f1e2f514764">
+      <Execution id="c5e03c5c-9bf4-4fd8-9c77-bb9d9a60a99d" />
+      <TestMethod codeBase="C:\git\Croupier\Croupier.Tests\bin\Debug\net8.0\Croupier.Tests.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="Croupier.Tests.CroupierTests" name="NewGameReturnsId" />
+    </UnitTest>
+    <UnitTest name="Croupier.Tests.CroupierTests.DrawCardDrawsCardOnTopOfDeck" storage="c:\git\croupier\croupier.tests\bin\debug\net8.0\croupier.tests.dll" id="bc389c86-95f2-56a2-8c3f-588e37d9d178">
+      <Execution id="39cbebd2-e689-45a2-a5a6-f7e17fbcc20f" />
+      <TestMethod codeBase="C:\git\Croupier\Croupier.Tests\bin\Debug\net8.0\Croupier.Tests.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="Croupier.Tests.CroupierTests" name="DrawCardDrawsCardOnTopOfDeck" />
+    </UnitTest>
+    <UnitTest name="Croupier.Tests.CroupierTests.NormalDeckContains52Cards" storage="c:\git\croupier\croupier.tests\bin\debug\net8.0\croupier.tests.dll" id="9d2ee00f-f190-32b7-5ef9-2c5503fb7f8f">
+      <Execution id="f97984f1-6399-4555-aeeb-7aa494315d19" />
+      <TestMethod codeBase="C:\git\Croupier\Croupier.Tests\bin\Debug\net8.0\Croupier.Tests.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="Croupier.Tests.CroupierTests" name="NormalDeckContains52Cards" />
+    </UnitTest>
+    <UnitTest name="Croupier.Tests.CroupierTests.NewGameIdLengthEqualsEight" storage="c:\git\croupier\croupier.tests\bin\debug\net8.0\croupier.tests.dll" id="3369af1c-e9ca-bebb-79c6-00bd1af362ef">
+      <Execution id="016116e5-442c-409b-a99e-ec403f3a09b5" />
+      <TestMethod codeBase="C:\git\Croupier\Croupier.Tests\bin\Debug\net8.0\Croupier.Tests.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="Croupier.Tests.CroupierTests" name="NewGameIdLengthEqualsEight" />
+    </UnitTest>
+    <UnitTest name="Croupier.Tests.CroupierTests.DrawCardRemovesCardFromDeck" storage="c:\git\croupier\croupier.tests\bin\debug\net8.0\croupier.tests.dll" id="55d9431b-d75a-b49a-a9ae-b74b239b906a">
+      <Execution id="4a6f3b2d-528a-4374-97fd-8e01ffaea53d" />
+      <TestMethod codeBase="C:\git\Croupier\Croupier.Tests\bin\Debug\net8.0\Croupier.Tests.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="Croupier.Tests.CroupierTests" name="DrawCardRemovesCardFromDeck" />
+    </UnitTest>
+    <UnitTest name="Croupier.Tests.CroupierTests.DrawingAllCardsEmptiesDeck" storage="c:\git\croupier\croupier.tests\bin\debug\net8.0\croupier.tests.dll" id="226d5946-baf1-6506-ddc7-4e01877606ea">
+      <Execution id="97bf5763-a489-4ef7-b5cc-3748936e25a8" />
+      <TestMethod codeBase="C:\git\Croupier\Croupier.Tests\bin\Debug\net8.0\Croupier.Tests.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="Croupier.Tests.CroupierTests" name="DrawingAllCardsEmptiesDeck" />
+    </UnitTest>
+    <UnitTest name="Croupier.Tests.CroupierTests.DrawCardDrawsOnlyOneCard" storage="c:\git\croupier\croupier.tests\bin\debug\net8.0\croupier.tests.dll" id="4f74a991-d890-bc0a-4793-026aa044837b">
+      <Execution id="bfa4a2df-e404-47ce-8876-8e951f6f989b" />
+      <TestMethod codeBase="C:\git\Croupier\Croupier.Tests\bin\Debug\net8.0\Croupier.Tests.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="Croupier.Tests.CroupierTests" name="DrawCardDrawsOnlyOneCard" />
+    </UnitTest>
+    <UnitTest name="Croupier.Tests.CroupierTests.MultipleDeckContainsCorrectNumberOfCards" storage="c:\git\croupier\croupier.tests\bin\debug\net8.0\croupier.tests.dll" id="28532d74-e399-4ef0-7be6-95e7edcbed42">
+      <Execution id="fc8a18af-b7da-459d-8dd3-85bbc6d2a51b" />
+      <TestMethod codeBase="C:\git\Croupier\Croupier.Tests\bin\Debug\net8.0\Croupier.Tests.dll" adapterTypeName="executor://xunit/VsTestRunner2/netcoreapp" className="Croupier.Tests.CroupierTests" name="MultipleDeckContainsCorrectNumberOfCards" />
+    </UnitTest>
+  </TestDefinitions>
+  <TestEntries>
+    <TestEntry testId="4f74a991-d890-bc0a-4793-026aa044837b" executionId="bfa4a2df-e404-47ce-8876-8e951f6f989b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9d2ee00f-f190-32b7-5ef9-2c5503fb7f8f" executionId="f97984f1-6399-4555-aeeb-7aa494315d19" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="936752f3-9fa4-e682-e9dd-c81b95bb96b6" executionId="07a786a0-ce17-49d5-bcb6-34ab04a0c64a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="226d5946-baf1-6506-ddc7-4e01877606ea" executionId="97bf5763-a489-4ef7-b5cc-3748936e25a8" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="bc389c86-95f2-56a2-8c3f-588e37d9d178" executionId="39cbebd2-e689-45a2-a5a6-f7e17fbcc20f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="28532d74-e399-4ef0-7be6-95e7edcbed42" executionId="fc8a18af-b7da-459d-8dd3-85bbc6d2a51b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="3369af1c-e9ca-bebb-79c6-00bd1af362ef" executionId="016116e5-442c-409b-a99e-ec403f3a09b5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="55d9431b-d75a-b49a-a9ae-b74b239b906a" executionId="4a6f3b2d-528a-4374-97fd-8e01ffaea53d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="05c769be-168f-8b17-063c-1f1e2f514764" executionId="c5e03c5c-9bf4-4fd8-9c77-bb9d9a60a99d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+  </TestEntries>
+  <TestLists>
+    <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
+  </TestLists>
+  <ResultSummary outcome="Failed">
+    <Counters total="9" executed="9" passed="8" failed="1" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    <Output>
+      <StdOut>[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.4.5+1caef2f33e (64-bit .NET 8.0.16)&#xD;
+[xUnit.net 00:00:00.43]   Discovering: Croupier.Tests&#xD;
+[xUnit.net 00:00:00.45]   Discovered:  Croupier.Tests&#xD;
+[xUnit.net 00:00:00.45]   Starting:    Croupier.Tests&#xD;
+[]&#xD;
+[xUnit.net 00:00:00.65]       Assert.Null() Failure&#xD;
+[xUnit.net 00:00:00.65]       Expected: (null)&#xD;
+[xUnit.net 00:00:00.65]       Actual:   2S&#xD;
+[xUnit.net 00:00:00.65]       Stack Trace:&#xD;
+[xUnit.net 00:00:00.65]         C:\git\Croupier\Croupier.Tests\CroupierTests.cs(148,0): at Croupier.Tests.CroupierTests.DrawingAllCardsEmptiesDeck()&#xD;
+[xUnit.net 00:00:00.65]         --- End of stack trace from previous location ---&#xD;
+[xUnit.net 00:00:00.75]   Finished:    Croupier.Tests&#xD;
+</StdOut>
+    </Output>
+    <RunInfos>
+      <RunInfo computerName="RM-8RM4BY3" outcome="Error" timestamp="2025-06-17T12:26:49.6846585-05:00">
+        <Text>[xUnit.net 00:00:00.65]     Croupier.Tests.CroupierTests.DrawingAllCardsEmptiesDeck [FAIL]</Text>
+      </RunInfo>
+    </RunInfos>
+  </ResultSummary>
+</TestRun>


### PR DESCRIPTION
This pull request introduces several enhancements and updates to the `Croupier` project, focusing on improving code quality, upgrading dependencies, refactoring endpoints, and enhancing test coverage. The most significant changes include updating the target framework to .NET 8, refactoring route parameters for endpoints, and improving test methods to align with the new route structure.

### Code Quality Improvements:
* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R9): Added guidelines for coding practices, such as limiting method parameters, using descriptive names, validating input data, and preferring async methods for I/O-bound operations.

### Framework and Dependency Upgrades:
* [`Croupier.App/Croupier.csproj`](diffhunk://#diff-862e43aefd4d75028bf4860ec879ce4cc73758b740c7d472878fd1b3a4ee09e4L4-R4): Updated the target framework from `net6.0` to `net8.0`.
* [`Croupier.Tests/Croupier.Tests.csproj`](diffhunk://#diff-f88d48d3e9e2067a54af699ff2490f6ed68b556e44bcc1ac535acf141bb84e31L4-R12): Updated the target framework to `net8.0` and upgraded testing-related dependencies to their latest versions.

### Endpoint Refactoring:
* [`Croupier.App/Endpoints/DeckEndpoint.cs`](diffhunk://#diff-a8bd0eb8c14a6671fb56f87498040de77ed5352016898e827a0969a79240e102L7-R16): Refactored endpoints to use route parameters instead of query strings (e.g., `/sessions/{sessionId}/draw-card`) and added support for optional parameters in routes. [[1]](diffhunk://#diff-a8bd0eb8c14a6671fb56f87498040de77ed5352016898e827a0969a79240e102L7-R16) [[2]](diffhunk://#diff-a8bd0eb8c14a6671fb56f87498040de77ed5352016898e827a0969a79240e102L29-R27)

### Test Enhancements:
* [`Croupier.Tests/CroupierTests.cs`](diffhunk://#diff-91d59e6439c7e776d5c1584457e2c7923b185623696be11080027d6249e8f84bL27-R57): Updated test methods to align with the new route structure, ensuring proper validation of endpoints and functionality. Added new assertions for null checks and improved test readability. [[1]](diffhunk://#diff-91d59e6439c7e776d5c1584457e2c7923b185623696be11080027d6249e8f84bL27-R57) [[2]](diffhunk://#diff-91d59e6439c7e776d5c1584457e2c7923b185623696be11080027d6249e8f84bL72-R113) [[3]](diffhunk://#diff-91d59e6439c7e776d5c1584457e2c7923b185623696be11080027d6249e8f84bL128-L150)
* [`Croupier.Tests/TestResults/test_results.trx`](diffhunk://#diff-9547cefd5b6496254c18d568683785bd17ae474d63daefa797fc72e9735e760fR1-R104): Added detailed test results, including failures for edge cases, such as drawing all cards from a deck.

### Session Management Improvements:
* [`Croupier.App/Workers/SessionManager.cs`](diffhunk://#diff-c4bd3f87dd0e6098de8576b76f4a07e728b2105ecadbd8006a7dbc47d68729acL11-R26): Improved session management logic by adding null checks and enhancing the robustness of methods like `DrawCard` to handle empty decks gracefully.